### PR TITLE
Fix bug when enabling then disabling syslog

### DIFF
--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -12,10 +12,4 @@ chown -R syslog:adm /var/vcap/data/syslog_forwarder/buffered
 
 mkdir -p /etc/rsyslog.d
 cp $(dirname $0)/../config/rsyslog.conf /etc/rsyslog.d/rsyslog.conf
-
-<% if p('syslog.migration.disabled') == true %>
-  service rsyslog stop
-<% else %>
-  service rsyslog restart
-<% end %>
-
+service rsyslog restart

--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -10,10 +10,12 @@ chmod 0755 ${LOGDIR}
 mkdir -p /var/vcap/data/syslog_forwarder/buffered
 chown -R syslog:adm /var/vcap/data/syslog_forwarder/buffered
 
-<% if p('syslog.migration.disabled') == true %>
-exit
-<% end %>
-
 mkdir -p /etc/rsyslog.d
 cp $(dirname $0)/../config/rsyslog.conf /etc/rsyslog.d/rsyslog.conf
-service rsyslog restart
+
+<% if p('syslog.migration.disabled') == true %>
+  service rsyslog stop
+<% else %>
+  service rsyslog restart
+<% end %>
+


### PR DESCRIPTION
- Because the rsyslog.conf file wasn't cleaned and the rsyslog service
was still up, even after setting the disabled property to true, the logs
were still being sent
- The fix both clears the file (the file will be empty when the disabled
flag is set to true), and stops the rsyslog service