### PR TITLE
syslog.migration.message_format can be set as rfc5424 explicitly

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -111,10 +111,11 @@ properties:
   syslog.migration.message_format:
     description: The message format used to send messages to remote endpoints. If no value is set, uses the upstream default.
     # if the upstream format changes, only then introduce a new format here (e.g. rfc5424)
-    default: ~
+    default: rfc5424
     enum:
-      - job_index
-      - job_index_id
+    - rfc5424
+    - job_index
+    - job_index_id
   syslog.migration.insistent_custom_rule:
     description: Rule to use even when the syslog migration is disabled.
     default: ""

--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -50,22 +50,10 @@ $UDPServerRun 514
 # following https://tools.ietf.org/html/rfc5424#section-6
 template(name="SyslogForwarderTemplate" type="list") {
 
-<% if_p('syslog.migration.message_format') do |message_format| %>
-  constant(value="<")
-  property(name="pri")
-  constant(value=">")
-  property(name="timestamp" dateFormat="rfc3339")
-  constant(value=" <%= spec.address %> ")
-  property(name="programname")
-<%   if message_format == 'job_index' %>
-  constant(value=" [job=<%= spec.job.name %> index=<%= spec.index %>] ")
-<%   elsif message_format == 'job_index_id' %>
-  constant(value=" [job=<%= spec.job.name %> index=<%= spec.index %> id=<%= spec.id %>] ")
-<%   else %>
-<%     raise "unknown syslog.migration.message_format: #{message_format}" %>
-<%   end %>
-  property(name="msg")
-<% end.else do %>
+<%
+  case p('syslog.migration.message_format')
+  when 'rfc5424'
+%>
   constant(value="<")
   property(name="pri")
   constant(value=">1 ")
@@ -79,7 +67,29 @@ template(name="SyslogForwarderTemplate" type="list") {
   # 47450 is CFF in https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
   constant(value=" [instance@47450 director=\"<%= p('syslog.director') %>\" deployment=\"<%= spec.deployment %>\" group=\"<%= spec.job.name %>\" az=\"<%= spec.az %>\" id=\"<%= spec.id %>\"] ")
   property(name="msg")
-<% end %>
+<% when 'job_index' %>
+  constant(value="<")
+  property(name="pri")
+  constant(value=">")
+  property(name="timestamp" dateFormat="rfc3339")
+  constant(value=" <%= spec.address %> ")
+  property(name="programname")
+  constant(value=" [job=<%= spec.job.name %> index=<%= spec.index %>] ")
+  property(name="msg")
+<% when 'job_index_id' %>
+  constant(value="<")
+  property(name="pri")
+  constant(value=">")
+  property(name="timestamp" dateFormat="rfc3339")
+  constant(value=" <%= spec.address %> ")
+  property(name="programname")
+  constant(value=" [job=<%= spec.job.name %> index=<%= spec.index %> id=<%= spec.id %>] ")
+  property(name="msg")
+<%
+  else
+    raise "unknown syslog.migration.message_format: #{p('syslog.migration.message_format')}"
+  end
+%>
 
 }
 

--- a/spec/fixtures/rsyslog_with_job_index_format.conf
+++ b/spec/fixtures/rsyslog_with_job_index_format.conf
@@ -7,9 +7,7 @@ template(name="SyslogForwarderTemplate" type="list") {
   property(name="timestamp" dateFormat="rfc3339")
   constant(value="  ")
   property(name="programname")
-
   constant(value=" [job=syslog_forwarder index=13] ")
-
   property(name="msg")
 
 

--- a/spec/fixtures/rsyslog_with_job_index_format.conf
+++ b/spec/fixtures/rsyslog_with_job_index_format.conf
@@ -1,0 +1,16 @@
+template(name="SyslogForwarderTemplate" type="list") {
+
+
+  constant(value="<")
+  property(name="pri")
+  constant(value=">")
+  property(name="timestamp" dateFormat="rfc3339")
+  constant(value="  ")
+  property(name="programname")
+
+  constant(value=" [job=syslog_forwarder index=13] ")
+
+  property(name="msg")
+
+
+}

--- a/spec/fixtures/rsyslog_with_job_index_id_format.conf
+++ b/spec/fixtures/rsyslog_with_job_index_id_format.conf
@@ -1,0 +1,16 @@
+template(name="SyslogForwarderTemplate" type="list") {
+
+
+  constant(value="<")
+  property(name="pri")
+  constant(value=">")
+  property(name="timestamp" dateFormat="rfc3339")
+  constant(value="  ")
+  property(name="programname")
+
+  constant(value=" [job=syslog_forwarder index=13 id=instance-id] ")
+
+  property(name="msg")
+
+
+}

--- a/spec/fixtures/rsyslog_with_job_index_id_format.conf
+++ b/spec/fixtures/rsyslog_with_job_index_id_format.conf
@@ -7,9 +7,7 @@ template(name="SyslogForwarderTemplate" type="list") {
   property(name="timestamp" dateFormat="rfc3339")
   constant(value="  ")
   property(name="programname")
-
   constant(value=" [job=syslog_forwarder index=13 id=instance-id] ")
-
   property(name="msg")
 
 

--- a/spec/fixtures/rsyslog_with_rfc5424_format.conf
+++ b/spec/fixtures/rsyslog_with_rfc5424_format.conf
@@ -1,0 +1,19 @@
+template(name="SyslogForwarderTemplate" type="list") {
+
+
+  constant(value="<")
+  property(name="pri")
+  constant(value=">1 ")
+  property(name="timestamp" dateFormat="rfc3339")
+  constant(value="  ")
+  property(name="app-name")
+  constant(value=" ")
+  property(name="procid")
+  constant(value=" ")
+  property(name="msgid")
+  # 47450 is CFF in https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
+  constant(value=" [instance@47450 director=\"\" deployment=\"\" group=\"syslog_forwarder\" az=\"\" id=\"instance-id\"] ")
+  property(name="msg")
+
+
+}

--- a/spec/helpers/bosh_template.rb
+++ b/spec/helpers/bosh_template.rb
@@ -13,6 +13,9 @@ module BoshTemplate
 
   def self.renderer_context(job_name, manifest, links)
     context = self.merge_job_spec_defaults(job_name, manifest)
+    context['job'] = { 'name' => job_name }
+    context['index'] = 13
+    context['id'] = 'instance-id'
     context['links'] = links
     context
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,3 +19,10 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 end
+
+module Fixtures
+  def self.read(filename)
+    path = File.expand_path(File.join(File.dirname(__FILE__), "fixtures", filename))
+    File.read(path)
+  end
+end

--- a/spec/syslog_forwarder_rsyslog_conf_spec.rb
+++ b/spec/syslog_forwarder_rsyslog_conf_spec.rb
@@ -27,8 +27,16 @@ RSpec.describe 'syslog_forwarder rsyslog.conf' do
     }
   end
 
+  it 'defaults to rsyslog beinge configured with the RFC5424 format' do
+    manifest = generate_manifest(minimum_manifest)
+    actual_template = BoshTemplate.render(template_path, job_name, manifest, links)
+
+    expected_message_format = Fixtures.read('rsyslog_with_rfc5424_format.conf')
+    expect(actual_template).to include expected_message_format
+  end
+
   it 'allows rsyslog to be configured with the RFC5424 format' do
-    manifest = generate_manifest_with_message_format(minimum_manifest, nil)
+    manifest = generate_manifest_with_message_format(minimum_manifest, 'rfc5424')
     actual_template = BoshTemplate.render(template_path, job_name, manifest, links)
 
     expected_message_format = Fixtures.read('rsyslog_with_rfc5424_format.conf')

--- a/spec/syslog_forwarder_rsyslog_conf_spec.rb
+++ b/spec/syslog_forwarder_rsyslog_conf_spec.rb
@@ -1,0 +1,78 @@
+require 'helpers/bosh_template'
+
+RSpec.describe 'syslog_forwarder rsyslog.conf' do
+  let(:template_path) { 'jobs/syslog_forwarder/templates/rsyslog.conf.erb' }
+  let(:job_name) { 'syslog_forwarder' }
+  let(:minimum_manifest) do
+    <<~MINIMUM_MANIFEST
+    instance_groups:
+    - name: syslog_forwarder
+      jobs:
+      - name: syslog_forwarder
+    MINIMUM_MANIFEST
+  end
+  let(:links) do
+    {
+      "syslog_storer" => {
+        "instances" => [
+          { "address" => "my.syslog_storer.bosh" }
+        ],
+        "properties" => {
+          "syslog" => {
+            "port" => "some-syslog-storer-port",
+            "transport" => "relp"
+          }
+        }
+      }
+    }
+  end
+
+  it 'allows rsyslog to be configured with the RFC5424 format' do
+    manifest = generate_manifest_with_message_format(minimum_manifest, nil)
+    actual_template = BoshTemplate.render(template_path, job_name, manifest, links)
+
+    expected_message_format = Fixtures.read('rsyslog_with_rfc5424_format.conf')
+    expect(actual_template).to include expected_message_format
+  end
+
+  it 'allows rsyslog to be configured with the job_index format' do
+    manifest = generate_manifest_with_message_format(minimum_manifest, 'job_index')
+    actual_template = BoshTemplate.render(template_path, job_name, manifest, links)
+
+    expected_message_format = Fixtures.read('rsyslog_with_job_index_format.conf')
+    expect(actual_template).to include expected_message_format
+  end
+
+  it 'allows rsyslog to be configured with the job_index_id format' do
+    manifest = generate_manifest_with_message_format(minimum_manifest, 'job_index_id')
+    actual_template = BoshTemplate.render(template_path, job_name, manifest, links)
+
+    expected_message_format = Fixtures.read('rsyslog_with_job_index_id_format.conf')
+    expect(actual_template).to include expected_message_format
+  end
+
+  it 'prevents rsyslog from being configured with unknown formats' do
+    manifest = generate_manifest_with_message_format(minimum_manifest, 'crazy-format')
+    expect {
+      BoshTemplate.render(template_path, job_name, manifest, links)
+    }.to raise_error(RuntimeError, "unknown syslog.migration.message_format: crazy-format")
+  end
+end
+
+def generate_manifest(raw_manifest)
+  manifest = YAML.load(raw_manifest)
+  yield(manifest) if block_given?
+  manifest
+end
+
+def generate_manifest_with_message_format(raw_manifest, message_format)
+  generate_manifest(raw_manifest) do |manifest|
+    manifest['instance_groups'][0]['jobs'][0]['properties'] = {
+      'syslog' => {
+        'migration' => {
+          'message_format' => message_format
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
OpsManager parsed manifest snippets don't allow a choice of 'no value' or 'some value', they allow 'some value' or 'some other value'. We need to be able to explicitly set `message_format: rfc5424`.

[#146276171]